### PR TITLE
Grouping reports be the same error reports. Formating logcat logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ If you update, don't forget to remove the includes/config.php file from the new 
 
 ## Change Log ##
 
+**Version 1.1.3-Abby**
+
+- *Add grouping and review reports by the same reports (by stacktraces). Now you can viewing/archiving/deleting reports by the same error*
+- *Formating LogCat and StackTrace logs*
+
 **Version 1.1.2-Abby**
 
 - *Add two methods for HTTP basic auth : PHP or htaccess/htpasswd files*

--- a/assets/functions-home.js
+++ b/assets/functions-home.js
@@ -26,9 +26,10 @@ function loadAll() {
 	loadChart('#chart2-1', REPORTS_EVOLUTION_LINE_CHART_ID, LINE_CHART_TYPE_ID);
 
 	loadLastReports();
+	loadMostErrorReports();
 	
 	// Refresh chart each 10min
-	setTimeout(function() { loadAll(); }, 60000 );
+	setTimeout(function() { loadAll(); }, 600000 );
 }
 
 function loadLastReports() {
@@ -37,6 +38,15 @@ function loadLastReports() {
 	$.ajax({ url:"?a=getlastreports", type:"get" })
 	 .done(function(data) {
 		 $('#lastreports').html(data);
+	 });	
+}
+
+function loadMostErrorReports() {
+	showLoaderIfEmpty('#mosterrorreports');
+	
+	$.ajax({ url:"?a=getmosterrorreports", type:"get" })
+	 .done(function(data) {
+		 $('#mosterrorreports').html(data);
 	 });	
 }
 

--- a/assets/functions-reports.js
+++ b/assets/functions-reports.js
@@ -24,6 +24,21 @@ function showReportDetails(id) {
 		});	
 }
 
+function showStackTraceDetails(id) {
+	$('#loader').show();
+
+	$.ajax({ url:"?a=getstacktrace", type:"post", data:{reportId:id} })
+		.done(function(data) {
+			try {
+				$('#stackTraceDialog').html(data);
+								
+			} catch (err) { console.error(err); }
+			
+			$('#stackTraceDialog').modal('show');
+			$('#loader').hide();
+		});	
+}
+
 function delReports() {
 	var arr = $('input[name="itemChecked"]');
 	var ids = ''; var sep = '';
@@ -77,6 +92,38 @@ function archiveReport(ids, loaderId) {
 		alert(data);
 		$('#reportDialog').modal('hide');
 		$('#reportDialog').html('');
+
+		$(loaderId).hide();
+		
+		window.location.reload();
+	});
+}
+
+function delReportByStacktrace(id, loaderId) {
+	if (!confirm('Do you really want to delete these report ?')) return;
+	
+	$(loaderId).show();
+
+	$.ajax({ url:"?a=delreportsbystacktrace", type:"post", data:{reportId:id} })
+	.done(function(data) {
+		alert(data);
+		$('#stackTraceDialog').modal('hide');
+		$('#stackTraceDialog').html('');
+
+		$(loaderId).hide();
+		
+		window.location.reload();
+	});
+}
+
+function archiveReportByStacktrace(id, loaderId) {
+	$(loaderId).show();
+
+	$.ajax({ url:"?a=archreportsbystacktrace", type:"post", data:{reportId:id} })
+	.done(function(data) {
+		alert(data);
+		$('#stackTraceDialog').modal('hide');
+		$('#stackTraceDialog').html(data);
 
 		$(loaderId).hide();
 		

--- a/controller.php
+++ b/controller.php
@@ -149,6 +149,17 @@ switch ($action) {
 				
 			} else { echo 'Report id is not valid !'; }
 		break;
+		
+//////// GET STACKTRACE
+	case 'getstacktrace' :
+			$reportId = @$_POST['reportId'];
+			if (!empty($reportId)) {
+				$stacktrace = DBHelper::fetchStackTrace($reportId);
+				
+				require_once('pages/stack_trace_details_dialog.php');
+				
+			} else { echo 'Report id is not valid !'; }
+		break;
 	
 //////// ARCHIVE REPORTS
 	case 'archreports' :
@@ -162,12 +173,34 @@ switch ($action) {
 			} else { echo 'Report id(s) is not valid !'; }
 		break;
 	
+//////// ARCHIVE REPORTS BY STACKTRACE
+	case 'archreportsbystacktrace' :
+			$reportId = @$_POST['reportId'];
+			if (!empty($reportId)) {			
+				$result = DBHelper::updateReportsStateByStacktrace($reportId, REPORT_STATE_ARCHIVED);
+				
+				echo 'Report(s) archived with success !';
+				
+			} else { echo 'Report id(s) is not valid !'; }
+		break;
+	
 //////// DEL REPORTS
 	case 'delreports' :
 			$reportIds = @$_POST['reportIds'];
 			if (!empty($reportIds)) {
 				$reportIds = explode(',', $reportIds);		
 				DBHelper::deleteReports($reportIds);
+				
+				echo 'Report(s) deleted with success !';
+				
+			} else { echo 'Report id(s) is not valid !'; }
+		break;
+	
+//////// DEL REPORTS BY STACKTRACE
+	case 'delreportsbystacktrace' :
+			$reportId = @$_POST['reportId'];
+			if (!empty($reportId)) {
+				DBHelper::deleteReportsByStacktrace($reportId);
 				
 				echo 'Report(s) deleted with success !';
 				
@@ -221,6 +254,11 @@ switch ($action) {
 //////// GET LAST REPORTS BOX
 	case 'getlastreports' :
 			require_once('pages/last_reports_box.php');
+		break;
+		
+//////// GET MOST ERROR REPORTS BOX
+	case 'getmosterrorreports' :
+			require_once('pages/most_error_reports_box.php');
 		break;
 		
 //////// GET CHART DATA

--- a/includes/define.php
+++ b/includes/define.php
@@ -11,8 +11,8 @@
  */
 
 define('APP_NAME', 'MAB-LAB');
-define('VERSION_NAME', '1.1.2-Abby');
-define('VERSION_CODE', 4);
+define('VERSION_NAME', '1.1.3-Abby');
+define('VERSION_CODE', 5);
 
 define('LOG_SEVERITY', 1); // could be 0=>DEBUG, 1=>INFO, 2=>WARNING, 3=>ERROR
 

--- a/includes/logcatline.class.php
+++ b/includes/logcatline.class.php
@@ -1,0 +1,48 @@
+<?php defined('DIRECT_ACCESS_CHECK') or die('DIRECT ACCESS NOT ALLOWED');
+/**
+ * Copyright (c) 2013 EIRL DEVAUX J. - Medialoha.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0
+ * which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/gpl.html
+ *
+ * Contributors:
+ *     EIRL DEVAUX J. - Medialoha - initial API and implementation
+ *     MAREK MASLANKA - Logintar - added review reports by the same errors and formatting logcat
+ */
+
+class LogCatLine
+{
+	public $time;
+	public $date;
+	public $type;
+	public $tag;
+	public $pid;
+	public $message;
+	private $valid;
+	
+	public function parse($string)
+	{
+		$this->valid = preg_match('/(?P<time>[\d\\-]+) (?P<date>[\d.:]+) (?P<type>\w)\/(?P<tag>.+)[ ]*\([ ]*(?P<pid>[\d]+)\): (?P<msg>.*)/', $string, $matches);
+		if($this->valid)
+		{
+			$this->time = $matches['time'];
+			$this->date = $matches['date'];
+			$this->type = $matches['type'];
+			$this->tag = $matches['tag'];
+			$this->pid = $matches['pid'];
+			$this->message = $matches['msg'];
+		}
+		else
+		{
+			$this->message = $string;
+		}
+	}
+	
+	public function isValid()
+	{
+		return $this->valid;
+	}
+}
+
+?>

--- a/includes/logcatlinehelper.class.php
+++ b/includes/logcatlinehelper.class.php
@@ -1,0 +1,61 @@
+<?php defined('DIRECT_ACCESS_CHECK') or die('DIRECT ACCESS NOT ALLOWED');
+/**
+ * Copyright (c) 2013 EIRL DEVAUX J. - Medialoha.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0
+ * which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/gpl.html
+ *
+ * Contributors:
+ *     EIRL DEVAUX J. - Medialoha - initial API and implementation
+ *     MAREK MASLANKA - Logintar - added review reports by the same errors and formatting logcat
+ */
+
+class LogcatLineHelper {
+	
+	public static function formatLine($logcatLine)
+	{
+		$color = LogcatLineHelper::getColorForType($logcatLine->type);
+		return '<span style="color:'.$color.'">'.$logcatLine->time.' '.$logcatLine->date.' '.$logcatLine->tag.' '.$logcatLine->message.'</span>';
+	}
+	
+	public static function formatLineAsTableRow($logcatLine)
+	{
+		$color = LogcatLineHelper::getColorForType($logcatLine->type);
+		return sprintf('
+		<tr style="color:%s">
+			<td>
+				<span style="display:block;white-space:nowrap;width:140px">%s&nbsp;%s</span>
+			</td>
+			<td>
+				%s
+			</td>
+			<td style="text-align:center">
+				%s
+			</td>
+			<td>
+				<span style="white-space:nowrap;">%s</span>
+			</td>
+		</tr>
+		', $color, $logcatLine->time, $logcatLine->date, $logcatLine->tag, $logcatLine->type, $logcatLine->message);
+	}
+	
+	private static function getColorForType($type)
+	{
+		switch ($type)
+		{
+			case 'I':
+				return '#007A00';
+			case 'W':
+				return '#FFAF00';
+			case 'E':
+				return '#FF0000';
+			case 'D':
+				return '#00007F';
+			case 'V':
+				return '#000000';
+			default:
+				return '#000000';
+		}
+	}
+}

--- a/includes/report.class.php
+++ b/includes/report.class.php
@@ -123,9 +123,7 @@ class Report {
 	}
 	
 	public function getFormatedLogCat() {
-		$search = '--------- beginning of ';
-		
-		return str_replace($search, '<hr/>', substr($this->logcat, strlen($search)));
+		return ReportHelper::getFormatedLogCatAsTable($this->logcat);
 	}
 	
 	public function getFormatedMemInfo() {
@@ -140,6 +138,10 @@ class Report {
 		require_once(BASE_PATH.'includes/customdataformatter.class.php');
 		
 		return CustomDataFormatter::format($this->custom_data); 
+	}
+	
+	public function getFormatedSystrace() {
+		return ReportHelper::translateQuoted($this->stack_trace);
 	}
 	
 	public function hasCustomData() { return (empty($this->custom_data)?false:true); }

--- a/includes/reporthelper.class.php
+++ b/includes/reporthelper.class.php
@@ -131,4 +131,44 @@ class ReportHelper {
 			</table><?php 
 		}
 	}
+	public static function getFormatedLogCatAsTable($logcatText) {
+		$search = '--------- beginning of ';
+		
+		$log = str_replace($search, '<hr/>', substr($logcatText, strlen($search)));
+    
+		$array = array();
+		$lines = explode("\n", $log);
+		foreach($lines as $line)
+		{
+			$logcat = new LogCatLine();
+			$logcat->parse($line);
+			$array[] = $logcat;
+		}
+		
+		// check if first log line is broken if it is then remove it
+		if(count($array) >= 2)
+		{		
+			if(!$array[0]->isValid() && $array[1]->isValid())
+			{
+				array_splice($array, 0, 1);
+			}
+		}
+		
+		$result = '';
+		$result .= '<table>';
+		$result .= '<tr><th>Time</th><th>Tag</th><th>Type</th><th>Message</th></tr>';
+		foreach($array as $logcatLine)
+		{
+			$logcatLine->message = ReportHelper::translateQuoted($logcatLine->message);
+			$result .= LogcatLineHelper::formatLineAsTableRow($logcatLine);
+		}
+		$result .= '</table>';
+		return $result;
+	}
+	
+	public static function translateQuoted($string) {
+		$search  = array("\t", "\n");
+		$replace = array("&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;",  "<br />");
+		return str_replace($search, $replace, $string);
+	}
 }

--- a/includes/stacktrace.class.php
+++ b/includes/stacktrace.class.php
@@ -1,0 +1,63 @@
+<?php defined('DIRECT_ACCESS_CHECK') or die('DIRECT ACCESS NOT ALLOWED');
+/**
+ * Copyright (c) 2013 EIRL DEVAUX J. - Medialoha.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0
+ * which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/gpl.html
+ *
+ * Contributors:
+ *     EIRL DEVAUX J. - Medialoha - initial API and implementation
+ *     MAREK MASLANKA - Logintar - added review reports by the same errors and formatting logcat
+ */
+
+
+class StackTrace {
+	
+	public $report_id;
+	
+	public $app_version_code;
+	public $app_version_name;
+	public $package_name;
+	
+	public $count;
+	public $last_crash_date;
+	
+	public $stack_trace;
+	
+	// CONSTRUCTOR
+	public static function createFromArray($values) {
+		$obj = new StackTrace();
+		foreach($values as $k=>$v) {
+			if (empty($v) || !is_string($k)) continue;
+			
+			if (in_array(strtoupper($k), ReportHelper::$mSerializedFields)) {
+				$tmp_arr = unserialize(base64_decode($v));
+				
+				if (sizeof($tmp_arr)==0) {
+					$obj->{$k} = null;
+					
+				} else {
+					if ($k=='display') {
+					} else if ($k=='shared_preferences') {
+					} else { $obj->{$k} = (object)$tmp_arr; }
+				}
+								
+			} else { $obj->{$k} = $v; }
+		}
+			
+		return $obj;
+	}
+	
+	public function getApplicationDesc() {
+		return ReportHelper::formatPackageName($this->package_name, true)." ".$this->app_version_name." #".$this->app_version_code;
+	}
+	
+	public function getTitle() {
+		return StackTraceHelper::getTitleFromStackTrace($this->stack_trace);
+	}
+	
+	public function getFormatedSystrace() {
+		return ReportHelper::translateQuoted($this->stack_trace);
+	}
+}

--- a/includes/stacktracehelper.class.php
+++ b/includes/stacktracehelper.class.php
@@ -1,0 +1,22 @@
+<?php defined('DIRECT_ACCESS_CHECK') or die('DIRECT ACCESS NOT ALLOWED');
+/**
+ * Copyright (c) 2013 EIRL DEVAUX J. - Medialoha.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0
+ * which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/gpl.html
+ *
+ * Contributors:
+ *     EIRL DEVAUX J. - Medialoha - initial API and implementation
+ *     MAREK MASLANKA - Logintar - added review reports by the same errors and formatting logcat
+ */
+
+
+class StackTraceHelper {
+	
+	
+	public static function getTitleFromStackTrace($trace) {
+		return substr($trace, 0, strpos($trace, "\n"));
+	}
+	
+}

--- a/index.php
+++ b/index.php
@@ -20,6 +20,10 @@ require_once('includes/debug.class.php');
 require_once('includes/dbhelper.class.php');
 require_once('includes/reporthelper.class.php');
 require_once('includes/report.class.php');
+require_once('includes/logcatline.class.php');
+require_once('includes/logcatlinehelper.class.php');
+require_once('includes/stacktrace.class.php');
+require_once('includes/stacktracehelper.class.php');
 
 // get page to display
 $pageId = isset($_GET['p'])?$_GET['p']:PAGE_ID_HOME;

--- a/pages/home.php
+++ b/pages/home.php
@@ -41,6 +41,14 @@ require_once('includes/charthelper.class.php');
 	</div> 
 </div>
 
+<div class="row" style="margin-top:30px;" >
+	<div class="span12" >
+		<h4>Most error reports</h4>
+		<div id="mosterrorreports" ></div>
+	</div> 
+</div>
+
+<div id="stackTraceDialog" class="modal hide fade" style="width:900px; margin-left:-450px;" ></div>
 <div id="reportDialog" class="modal hide fade" style="width:1000px; margin-left:-500px; height:700px;" ></div>
 
 <!--[if lte IE 8]><script language="javascript" type="text/javascript" src="libs/flot/excanvas.min.js"></script><![endif]-->

--- a/pages/last_reports_box.php
+++ b/pages/last_reports_box.php
@@ -41,5 +41,3 @@ $arr = DBHelper::selectRows(TBL_REPORTS, REPORT_STATE.'!='.REPORT_STATE_ARCHIVED
 	} else { ?><tr><td colspan="5" class="muted" >No repords recorded yet...</td></tr><?php } ?>
 </tbody>
 </table>
-
-<div id="reportDialog" class="modal hide fade" style="width:900px; margin-left:-450px;" ></div>

--- a/pages/most_affected_devices_box.php
+++ b/pages/most_affected_devices_box.php
@@ -40,5 +40,3 @@ $arr = DBHelper::selectRows(TBL_REPORTS, null, 'count DESC', REPORT_PHONE_MODEL.
 	} else { ?><tr><td colspan="2" class="muted" >No reports recorded yet...</td></tr><?php } ?>
 </tbody>
 </table>
-
-<div id="reportDialog" class="modal hide fade" style="width:900px; margin-left:-450px;" ></div>

--- a/pages/most_error_reports_box.php
+++ b/pages/most_error_reports_box.php
@@ -1,0 +1,43 @@
+<?php defined('DIRECT_ACCESS_CHECK') or die('DIRECT ACCESS NOT ALLOWED');
+/**
+ * Copyright (c) 2013 EIRL DEVAUX J. - Medialoha.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0
+ * which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/gpl.html
+ *
+ * Contributors:
+ *     EIRL DEVAUX J. - Medialoha - initial API and implementation
+ *     MAREK MASLANKA - Logintar - added review reports by the same errors and formatting logcat
+ */
+
+// get reports preferences
+$cfg = CfgHelper::getInstance();
+
+?>
+<table class="table table-condensed table-hover reports-tbl" >
+<thead>
+	<tr>
+		<th>Package name</th>
+		<th>Ver. name</th>
+ 		<th>Stack trace</th>
+ 		<th>Count</th>
+	</tr>		
+</thead>
+<tbody>
+<?php
+	$stacktraces = DBHelper::fetchStackTraces(10);
+	if (is_array($stacktraces) && sizeof($stacktraces) > 0)
+	{
+		foreach($stacktraces as $stacktrace)
+		{ ?>
+	<tr style="cursor:pointer;" onclick="showStackTraceDetails('<?php echo $stacktrace->report_id; ?>');" >
+		<td style="" ><?php echo $stacktrace->package_name; ?></td>
+		<td style="" ><?php echo $stacktrace->app_version_name; ?></td>
+		<td style="" ><?php echo $stacktrace->stack_trace; ?></td>
+	 	<td style="" ><?php echo $stacktrace->count; ?></td>
+	</tr>
+<?php } 
+	} else { ?><tr><td colspan="5" class="muted" >No repords recorded yet...</td></tr><?php } ?>
+</tbody>
+</table>

--- a/pages/report_details_dialog.php
+++ b/pages/report_details_dialog.php
@@ -121,8 +121,8 @@
   			<dt>Settings Secure</dt><dd><br/><?php echo ReportHelper::displayObjectValuesToHTMLArray($report->settings_secure); ?></dd>
   		</dl>
   	</div>
-  	
-  	<div class="tab-pane" id="report-stacktrace" ><?php echo $report->stack_trace; ?></div>
+	
+  	<div class="tab-pane" id="report-stacktrace" style="color:red" ><?php echo $report->getFormatedSystrace(); ?></div>
   	<div class="tab-pane" id="report-logcat" ><?php echo $report->getFormatedLogCat(); ?></div>
   	<div class="tab-pane" id="report-eventslog" ><?php echo $report->eventslog; ?></div>
   	<div class="tab-pane" id="report-meminfo" ><?php echo $report->getFormatedMemInfo(); ?></div>

--- a/pages/stack_trace_details_dialog.php
+++ b/pages/stack_trace_details_dialog.php
@@ -1,0 +1,90 @@
+<?php defined('DIRECT_ACCESS_CHECK') or die('DIRECT ACCESS NOT ALLOWED');
+/**
+ * Copyright (c) 2013 EIRL DEVAUX J. - Medialoha.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0
+ * which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/gpl.html
+ *
+ * Contributors:
+ *     EIRL DEVAUX J. - Medialoha - initial API and implementation
+ *     MAREK MASLANKA - Logintar - added review reports by the same errors and formatting logcat
+ */
+
+// get reports preferences
+$cfg = CfgHelper::getInstance();
+$reportsWithStackTrace = DBHelper::selectRows(TBL_REPORTS, REPORT_STACK_TRACE.'= "'.addslashes($stacktrace->stack_trace).'"', REPORT_CRASH_DATE.' DESC', REPORT_ID.','.REPORT_CRASH_DATE.','.REPORT_PHONE_MODEL.','.REPORT_ANDROID_VERSION, null, "10", false);
+
+?>
+<div class="modal-header">
+	<img id="stdlgloader" src="assets/images/loader.gif" style="float:right; height:25px; margin-right:0px;" />
+	<script >$('#stdlgloader').hide();</script>
+  <h4>Error: <?php echo $stacktrace->getTitle(); ?>
+  </h4>
+</div>
+
+<div class="modal-body" style="clear:both; height:800px; max-height:620px;" >
+	<ul id="stacktraceTabs" class="nav nav-tabs" >
+	  <li class="active" ><a href="#stacktrace-details" data-toggle="tab" >Details</a></li>
+	  <li><a href="#stacktrace-other" data-toggle="tab" >Reports</a></li>
+	  <li><a href="#stacktrace-stack" data-toggle="tab" >Stack Trace</a></li>
+	</ul>
+	
+	<div class="tab-content">	
+		<div class="tab-pane active" id="stacktrace-details" >
+			<dl class="dl-horizontal">
+				<dt>Application</dt><dd><?php echo $stacktrace->getApplicationDesc(); ?></dd>
+				<dt>Package</dt><dd><?php echo $stacktrace->package_name; ?></dd>
+				<dt>Times</dt><dd><?php echo $stacktrace->count; ?></dd>
+				<dt>Last time crash</dt><dd><?php echo $stacktrace->last_crash_date; ?></dd>
+			</dl>
+		</div>
+		
+		<div class="tab-pane" id="stacktrace-other" >
+			<table class="table table-condensed table-hover reports-tbl" >
+				<thead>
+					<tr>
+						<th>ID</th>
+						<th>Date</th>
+				 		<th>Android</th>
+				 		<th>Phone Model</th>
+					</tr>		
+				</thead>
+				<tbody>
+				<?php 
+					foreach($reportsWithStackTrace as $values)
+					{ 
+						$st = Report::createFromArray($values);
+				?>
+					<tr style="cursor:pointer;" onclick="showReportDetails('<?php echo $st->report_id; ?>');" >
+						<td class="id" ><?php echo $st->report_id; ?></td>
+						<td class="date" ><?php echo ReportHelper::formatDate($st->user_crash_date, $cfg->getDateFormat()); ?></td>
+						<td class="android-version" ><?php echo $st->android_version; ?></td>
+					 	<td class="phone-model" ><?php echo $st->phone_model; ?></td>
+					</tr>
+				<?php
+					}
+				?>
+				</tbody>
+			</table>
+		</div>
+		
+		<div class="tab-pane" id="stacktrace-stack" style="color:red" >
+			<?php echo $stacktrace->getFormatedSystrace(); ?>
+		</div>
+	</div>
+ 
+	<script>
+	  $(function () { $('#stacktraceTabs a:first').tab('show'); });
+	</script>
+</div>
+
+<div class="modal-footer">
+  <a href="#" class="btn" data-dismiss="modal" >Close</a>
+  
+  <a href="#" class="btn" onclick="archiveReportByStacktrace('<?php echo $stacktrace->report_id; ?>', '#stdlgloader');" >
+  	<i class="icon-folder-open" ></i>&nbsp;Archive (<?php echo $stacktrace->count; ?>) reports</a>
+  	
+  <a href="#" class="btn btn-danger" onclick="delReportByStacktrace('<?php echo $stacktrace->report_id; ?>', '#stdlgloader');" >
+  	<i class="icon-trash icon-white" ></i>&nbsp;Delete (<?php echo $stacktrace->count; ?>) reports</a>
+</div>


### PR DESCRIPTION
Add formatting Stacktrace and Logcat logs like in Eclipse's Logcat.
Grouping reports by the same error reports using stacktrace log. Now is
able to view/archive/delete reports with the same error. Add also new
box to home page and new dialog window with information about reports
(e.g. times error occurs or last time error occurs)
