### PR TITLE
Fix bug serializing values

### DIFF
--- a/includes/reporthelper.class.php
+++ b/includes/reporthelper.class.php
@@ -83,7 +83,7 @@ class ReportHelper {
 		foreach ($json as $k=>$v) {
 			$k = strtolower($k);
 			
-			if (in_array($k, self::$mSerializedFields)) {
+			if (in_array(strtoupper($k), self::$mSerializedFields)) {
 				 $values[$k] = base64_encode(serialize($v));
 				
 			} else {


### PR DESCRIPTION
`strtolower` is called on `$k` before it is checked to be in `self::$mSerializedFields`(which is in upper case) causing it to always return false
