### PR TITLE
Larger custom_data field to allow more custom data to be sent from device

### DIFF
--- a/install/db-install.sql
+++ b/install/db-install.sql
@@ -26,7 +26,7 @@ CREATE TABLE `%PREFIX%reports` (
   `build` text,
   `total_mem_size` varchar(25) DEFAULT NULL,
   `available_mem_size` varchar(25) DEFAULT NULL,
-  `custom_data` varchar(255) DEFAULT NULL,
+  `custom_data` text,
   `stack_trace` text,
   `initial_configuration` text,
   `crash_configuration` text,


### PR DESCRIPTION
Custom data can be longer than 255 chars and so it is wiser to use TEXT as the field type (otherwise the serialized data will be truncated and thus corrupted and FALSE will returned from unserialize in Report::createFromArray)
